### PR TITLE
feat: add default background to optimize result for png or other image with opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ var photomosaic = new PhotoMosaic({
 | tileWidth     | 5             | The tile division width for creating mosaic (in px) |
 | tileHeight    | 5             | The tile division height for creating mosaic (in px) |
 | tileShape     | ‘circle'      | The shape of the tiles (**circle** or **rectangle**) |
-| opacity       | 1             | opacity of the resulting image           |
+| opacity       | 1             | Opacity of the resulting image           |
 | width         | null          | [Mandatory] Width of the resulting image |
 | height        | null          | [Mandatory] Height of the resulting image |
+| defaultBackground | 'rgba(0, 0, 0, 0' | Default background to optimize result for png or other image with opacity |
 
 ### Example
 ```javascript

--- a/src/photomosaic.js
+++ b/src/photomosaic.js
@@ -53,11 +53,12 @@
           'tileShape': 'circle',
           'opacity': 1,
           'width': null,
-          'height': null
+          'height': null,
+          'defaultBackground': 'rgba(0, 0, 0, 0)'
       };
 
       /**
-       * Renders the image on a canvas before processing the pixels
+       * Renders the image with an default background on a canvas before processing the pixels
        * @return {object} Context of the canvas created
        */
       PhotoMosaic.prototype.renderImage = function() {
@@ -68,6 +69,13 @@
           canvas.height = options.tileHeight * options.divY;
 
           var context = canvas.getContext('2d');
+  
+          context.fillStyle = options.defaultBackground;
+          context.beginPath();
+          context.rect(0, 0, canvas.width, canvas.height);
+          context.closePath();
+          context.fill();
+          
           context.drawImage(options.image, 0, 0, canvas.width, canvas.height);
           return context;
       };


### PR DESCRIPTION
Add a new option "defaultBackground", when calling #renderImage, it will fill the canvas with the
color of this option before origin image is draw